### PR TITLE
fix: swap gold and iron nugget outputs for horse armor mincer recipes

### DIFF
--- a/common/src/main/resources/data/farm_and_charm/recipe/mincer/gold_nugget_from_horse_armor.json
+++ b/common/src/main/resources/data/farm_and_charm/recipe/mincer/gold_nugget_from_horse_armor.json
@@ -5,7 +5,7 @@
   },
   "recipe_type": "WOOD",
   "result": {
-    "id": "minecraft:iron_nugget",
+    "id": "minecraft:gold_nugget",
     "count": 12
   }
 }

--- a/common/src/main/resources/data/farm_and_charm/recipe/mincer/iron_nugget_from_horse_armor.json
+++ b/common/src/main/resources/data/farm_and_charm/recipe/mincer/iron_nugget_from_horse_armor.json
@@ -5,7 +5,7 @@
   },
   "recipe_type": "WOOD",
   "result": {
-    "id": "minecraft:gold_nugget",
+    "id": "minecraft:iron_nugget",
     "count": 12
   }
 }


### PR DESCRIPTION
This was previously fixed in the 1.20.1 branch in https://github.com/Let-s-Do-Collection/Let-s-Do-Collection/issues/174 but the
changes didn't make it into the 1.21.1 branch.