### PR TITLE
Reset the bowl state/sprite when taking out items

### DIFF
--- a/common/src/main/java/net/satisfy/farm_and_charm/core/block/CraftingBowlBlock.java
+++ b/common/src/main/java/net/satisfy/farm_and_charm/core/block/CraftingBowlBlock.java
@@ -112,6 +112,7 @@ public class CraftingBowlBlock extends BaseEntityBlock {
                     bowl.setItem(i, ItemStack.EMPTY);
                 }
             }
+            level.setBlock(pos, state.setValue(STIRRED, 0), 3);
             bowl.setChanged();
             return InteractionResult.sidedSuccess(level.isClientSide);
         }
@@ -134,6 +135,7 @@ public class CraftingBowlBlock extends BaseEntityBlock {
                     player.getInventory().add(out.copy());
                     bowl.setItem(4, ItemStack.EMPTY);
                     level.setBlock(pos, state.setValue(STIRRED, 0), 3);
+                    bowl.setChanged();
                     return InteractionResult.SUCCESS;
                 }
             }


### PR DESCRIPTION
After a successful stirring, the bowl doesn't properly reset after taking out items, making it impossible to successfully stir the next bath of ingredients, without having to break the bowl.

This PR explicitly resets the `STIRRED` property and calls `setChanged` for both when the player takes ingredients or the result item out of the bowl.