### PR TITLE
Mincer and crafting bowl: Confine interaction to the main hand

### DIFF
--- a/common/src/main/java/net/satisfy/farm_and_charm/core/block/CraftingBowlBlock.java
+++ b/common/src/main/java/net/satisfy/farm_and_charm/core/block/CraftingBowlBlock.java
@@ -98,13 +98,12 @@ public class CraftingBowlBlock extends BaseEntityBlock {
         if (!(be instanceof CraftingBowlBlockEntity bowl)) return InteractionResult.PASS;
 
         ItemStack main = player.getMainHandItem();
-        ItemStack off = player.getOffhandItem();
-        boolean anyHeld = !main.isEmpty() || !off.isEmpty();
+        boolean anyHeld = !main.isEmpty();
 
         int stirring = state.getValue(STIRRING);
         int stirred = state.getValue(STIRRED);
 
-        if (player.isShiftKeyDown() && !anyHeld) {
+        if (player.isShiftKeyDown()) {
             for (int i = 0; i < bowl.getContainerSize(); i++) {
                 ItemStack stack = bowl.getItem(i);
                 if (!stack.isEmpty()) {
@@ -118,12 +117,11 @@ public class CraftingBowlBlock extends BaseEntityBlock {
         }
 
         if (anyHeld && stirring == 0) {
-            ItemStack src = !main.isEmpty() ? main : off;
             if (bowl.canAddItem()) {
-                ItemStack one = src.copy();
+                ItemStack one = main.copy();
                 one.setCount(1);
                 bowl.addItemStack(one);
-                if (!player.isCreative()) src.shrink(1);
+                if (!player.isCreative()) main.shrink(1);
                 return InteractionResult.SUCCESS;
             }
         }
@@ -156,7 +154,7 @@ public class CraftingBowlBlock extends BaseEntityBlock {
             }
         }
 
-        return InteractionResult.PASS;
+        return InteractionResult.SUCCESS;
     }
 
     @Override

--- a/common/src/main/java/net/satisfy/farm_and_charm/core/block/CraftingBowlBlock.java
+++ b/common/src/main/java/net/satisfy/farm_and_charm/core/block/CraftingBowlBlock.java
@@ -130,7 +130,7 @@ public class CraftingBowlBlock extends BaseEntityBlock {
             if (stirred >= STIRS_NEEDED && stirring == 0) {
                 ItemStack out = bowl.getItem(4);
                 if (!out.isEmpty()) {
-                    player.getInventory().add(out.copy());
+                    popResource(level, pos, out);
                     bowl.setItem(4, ItemStack.EMPTY);
                     level.setBlock(pos, state.setValue(STIRRED, 0), 3);
                     bowl.setChanged();

--- a/common/src/main/java/net/satisfy/farm_and_charm/core/block/MincerBlock.java
+++ b/common/src/main/java/net/satisfy/farm_and_charm/core/block/MincerBlock.java
@@ -122,10 +122,7 @@ public class MincerBlock extends BaseEntityBlock {
             return InteractionResult.PASS;
         }
 
-        ItemStack offhandStack = player.getItemInHand(InteractionHand.OFF_HAND);
-
-        InteractionHand usedHand = !offhandStack.isEmpty() ? InteractionHand.OFF_HAND : InteractionHand.MAIN_HAND;
-        ItemStack playerStack = player.getItemInHand(usedHand);
+        ItemStack playerStack = player.getItemInHand(InteractionHand.MAIN_HAND);
 
         if (player.isShiftKeyDown()) {
             if (!level.isClientSide) {
@@ -146,7 +143,7 @@ public class MincerBlock extends BaseEntityBlock {
 
         if (!playerStack.isEmpty() && crank == 0) {
             if (!mincer.hasValidRecipe(level, playerStack)) {
-                return InteractionResult.PASS;
+                return InteractionResult.SUCCESS;
             }
 
             if (player.isCreative()) {
@@ -160,12 +157,7 @@ public class MincerBlock extends BaseEntityBlock {
                 if (inputStack.is(playerStack.getItem())) {
                     int countInPlayerHand = playerStack.getCount();
                     int insertableCount = inputStack.getMaxStackSize() - inputStack.getCount();
-                    int countToTakeFromPlayer = 0;
-
-                    while (countToTakeFromPlayer < insertableCount && countToTakeFromPlayer < countInPlayerHand) {
-                        countToTakeFromPlayer += 1;
-                    }
-
+                    int countToTakeFromPlayer = Math.min(insertableCount, countInPlayerHand);
                     if (countToTakeFromPlayer > 0) {
                         inputStack.setCount(inputStack.getCount() + countToTakeFromPlayer);
                         mincer.setItem(mincer.INPUT_SLOT, inputStack);
@@ -192,24 +184,6 @@ public class MincerBlock extends BaseEntityBlock {
                 level.setBlock(pos, state.setValue(CRANKED, 0), Block.UPDATE_ALL);
                 return InteractionResult.SUCCESS;
             }
-
-            if (level instanceof ServerLevel serverWorld) {
-                for (ItemStack stack : mincer.getItems()) {
-                    if (!stack.isEmpty() && mincer.getItem(mincer.OUTPUT_SLOT) != stack) {
-                        ItemParticleOption particleOption = new ItemParticleOption(ParticleTypes.ITEM, stack);
-                        serverWorld.sendParticles(particleOption, pos.getX() + 0.5, pos.getY() + 1.1, pos.getZ() + 0.4, 3, 0.2, 0.1, 0, 0.1);
-                    }
-                }
-            }
-
-            if (crank <= 6) {
-                level.setBlock(pos, state.setValue(CRANK, 10), Block.UPDATE_ALL);
-                mincer.addCrankImpulse(0.35F);
-                level.playSound(null, pos, SoundEventRegistry.MINCER_CRANKING.get(), SoundSource.BLOCKS, 1.0F, 2.5F);
-                return InteractionResult.SUCCESS;
-            }
-
-            return InteractionResult.PASS;
         }
 
         if (level instanceof ServerLevel serverWorld) {
@@ -227,7 +201,7 @@ public class MincerBlock extends BaseEntityBlock {
             return InteractionResult.SUCCESS;
         }
 
-        return InteractionResult.PASS;
+        return InteractionResult.SUCCESS;
     }
 
     @Override


### PR DESCRIPTION
Currently the mincer will eagerly take items from the off hand, then from main hand if the off hand is empty. This leads to the mincer silently failing when the player has an ingredient on the main hand and an unsupported item on the off hand (a shield or certain blocks), leading to confusion.

This PR changes that by only taking ingredients out of the main hand. The mincer will still fail if the main hand has an unsupported item, but the hand swing will trigger to signal that (instead of no animation at all).

I also applied the same fix to the crafting bowl. Previously the bowl would take items from both hands, sometimes it could be a shield or an unsupported item, which ruins the recipe. The bowl now also explicitly pops the result item out for visibilty.

Both the crafting bowl and the mincer can now be operated smoothly as long as the main hand is empty.

The PR also merges 2 identical branches in `MincerBlock#useWithoutItem`.