### PR TITLE
Stove: properly reset lit state and dont reset cooking progress unless recipe is interrupted

### DIFF
--- a/common/src/main/java/net/satisfy/farm_and_charm/core/block/entity/StoveBlockEntity.java
+++ b/common/src/main/java/net/satisfy/farm_and_charm/core/block/entity/StoveBlockEntity.java
@@ -392,14 +392,16 @@ public class StoveBlockEntity extends BlockEntity implements BlockEntityTicker<S
         if (stack.getCount() > this.getMaxStackSize()) {
             stack.setCount(this.getMaxStackSize());
         }
-        boolean hasIngredientChange = false;
-        for (int ingredientSlot : INGREDIENT_SLOTS) {
-            if (!ItemStack.isSameItemSameComponents(this.getItem(ingredientSlot), stackInSlot)) {
-                hasIngredientChange = true;
+
+        boolean isIngredientSlot = false;
+        for (int islot : INGREDIENT_SLOTS) {
+            if (slot == islot) {
+                isIngredientSlot = true;
                 break;
             }
         }
-        if (hasIngredientChange && !dirty) {
+
+        if (isIngredientSlot && !dirty) {
             this.cookTimeTotal = TOTAL_COOKING_TIME;
             this.cookTime = 0;
             this.setChanged();

--- a/common/src/main/java/net/satisfy/farm_and_charm/core/block/entity/StoveBlockEntity.java
+++ b/common/src/main/java/net/satisfy/farm_and_charm/core/block/entity/StoveBlockEntity.java
@@ -175,6 +175,7 @@ public class StoveBlockEntity extends BlockEntity implements BlockEntityTicker<S
                 this.cookTime = 0;
                 if (state.getValue(StoveBlock.LIT)) {
                     world.setBlock(pos, state.setValue(StoveBlock.LIT, false), Block.UPDATE_ALL);
+                    setChanged();
                 }
                 return;
             }
@@ -203,10 +204,12 @@ public class StoveBlockEntity extends BlockEntity implements BlockEntityTicker<S
         } else if (recipe.isPresent() && !canCraft(recipe.get(), access)) {
             this.cookTime = 0;
         }
-        if (initialBurningState != isBurning() || state.getValue(StoveBlock.LIT) != (burnTime > 0 || (burnTime == 0 && burnTimeTotal > 0))) {
-            world.setBlock(pos, state.setValue(StoveBlock.LIT, burnTime > 0 || (burnTime == 0 && burnTimeTotal > 0)), Block.UPDATE_ALL);
+
+        if (state.getValue(StoveBlock.LIT) != isBurning()) {
+            world.setBlock(pos, state.setValue(StoveBlock.LIT, isBurning()), Block.UPDATE_ALL);
             dirty = true;
         }
+
         if (dirty) {
             setChanged();
         }


### PR DESCRIPTION
Previously the stove lit animation will continue to run after the stove has run out of fuel. I've simplified the conditions for it so the state change is now handled properly.

The stove also resets the cooking progress (`cookTime`) when you modify any item in the ingredient slots in any way, as well as in the output slot and the fuel slot. I've fixed that as well. The progress now resets only when the recipe changes. 

Do note that the progress stalls when out of fuel, but continues when fuel is added. We can reverse the progress like how vannilla minecraft does, but I wanna hear your opinion on this. Cheers!