### PR TITLE
Crafting Bowl: Simplify implemenation

### DIFF
--- a/common/src/main/java/net/satisfy/farm_and_charm/client/renderer/block/CraftingBowlRenderer.java
+++ b/common/src/main/java/net/satisfy/farm_and_charm/client/renderer/block/CraftingBowlRenderer.java
@@ -43,7 +43,7 @@ public class CraftingBowlRenderer implements BlockEntityRenderer<CraftingBowlBlo
         pose.mulPose(Axis.XP.rotationDegrees(180));
         pose.translate(0.5f, -1.5f, -0.5f);
 
-        ResourceLocation tex = be.getStirringProgress() >= CraftingBowlBlock.STIRS_NEEDED
+        ResourceLocation tex = be.getStirringProgress() > CraftingBowlBlock.STIRS_NEEDED
                 ? ResourceLocation.fromNamespaceAndPath(FarmAndCharm.MOD_ID, "textures/entity/crafting_bowl_full.png")
                 : ResourceLocation.fromNamespaceAndPath(FarmAndCharm.MOD_ID, "textures/entity/crafting_bowl.png");
 

--- a/common/src/main/java/net/satisfy/farm_and_charm/core/block/CraftingBowlBlock.java
+++ b/common/src/main/java/net/satisfy/farm_and_charm/core/block/CraftingBowlBlock.java
@@ -103,7 +103,7 @@ public class CraftingBowlBlock extends BaseEntityBlock {
         int stirring = state.getValue(STIRRING);
         int stirred = state.getValue(STIRRED);
 
-        if (player.isShiftKeyDown()) {
+        if (player.isShiftKeyDown() || (stirred >= STIRS_NEEDED && stirring == 0)) {
             for (int i = 0; i < bowl.getContainerSize(); i++) {
                 ItemStack stack = bowl.getItem(i);
                 if (!stack.isEmpty()) {
@@ -122,21 +122,12 @@ public class CraftingBowlBlock extends BaseEntityBlock {
                 one.setCount(1);
                 bowl.addItemStack(one);
                 if (!player.isCreative()) main.shrink(1);
+                level.setBlock(pos, state.setValue(STIRRED, 0), 3);
                 return InteractionResult.SUCCESS;
             }
         }
 
-        if (!anyHeld) {
-            if (stirred >= STIRS_NEEDED && stirring == 0) {
-                ItemStack out = bowl.getItem(4);
-                if (!out.isEmpty()) {
-                    popResource(level, pos, out);
-                    bowl.setItem(4, ItemStack.EMPTY);
-                    level.setBlock(pos, state.setValue(STIRRED, 0), 3);
-                    bowl.setChanged();
-                    return InteractionResult.SUCCESS;
-                }
-            }
+        if (!anyHeld || !bowl.canAddItem()) {
             if (level instanceof ServerLevel server) {
                 RandomSource r = server.random;
                 for (int i = 0; i < 4; i++) {

--- a/common/src/main/java/net/satisfy/farm_and_charm/core/block/entity/CraftingBowlBlockEntity.java
+++ b/common/src/main/java/net/satisfy/farm_and_charm/core/block/entity/CraftingBowlBlockEntity.java
@@ -162,13 +162,17 @@ public class CraftingBowlBlockEntity extends RandomizableContainerBlockEntity im
         return Optional.ofNullable(matchExact(all));
     }
 
+    private int numberOfIngredientsInBowl() {
+        int num = 0;
+        if (!this.getItem(0).isEmpty()) num += 1;
+        if (!this.getItem(1).isEmpty()) num += 1;
+        if (!this.getItem(2).isEmpty()) num += 1;
+        if (!this.getItem(3).isEmpty()) num += 1;
+        return num;
+    }
+
     private CraftingBowlRecipe matchExact(List<RecipeHolder<CraftingBowlRecipe>> recipes) {
-        ItemStack[] inputs = new ItemStack[4];
-        int present = 0;
-        for (int i = 0; i < 4; i++) {
-            inputs[i] = this.getItem(i);
-            if (!inputs[i].isEmpty()) present++;
-        }
+        int present = this.numberOfIngredientsInBowl();
         for (RecipeHolder<CraftingBowlRecipe> holder : recipes) {
             CraftingBowlRecipe r = holder.value();
             int needed = 0;
@@ -180,7 +184,8 @@ public class CraftingBowlBlockEntity extends RandomizableContainerBlockEntity im
                 if (ing.isEmpty()) continue;
                 boolean matched = false;
                 for (int i = 0; i < 4; i++) {
-                    if (!used[i] && !inputs[i].isEmpty() && ing.test(inputs[i])) {
+                    ItemStack item = this.getItem(i);
+                    if (!used[i] && !item.isEmpty() && ing.test(item)) {
                         used[i] = true;
                         matched = true;
                         break;
@@ -228,7 +233,7 @@ public class CraftingBowlBlockEntity extends RandomizableContainerBlockEntity im
             int stirred = state.getValue(CraftingBowlBlock.STIRRED);
             if (stirring > 0) {
                 if (stirred < CraftingBowlBlock.STIRS_NEEDED) stirred += 1;
-                if (stirred == CraftingBowlBlock.STIRS_NEEDED) {
+                if (stirred == CraftingBowlBlock.STIRS_NEEDED && this.numberOfIngredientsInBowl() > 0) {
                     Optional<CraftingBowlRecipe> recipe = be.findRecipe(level);
                     if (recipe.isPresent()) {
                         stirred += 1;

--- a/common/src/main/java/net/satisfy/farm_and_charm/core/block/entity/CraftingBowlBlockEntity.java
+++ b/common/src/main/java/net/satisfy/farm_and_charm/core/block/entity/CraftingBowlBlockEntity.java
@@ -227,30 +227,15 @@ public class CraftingBowlBlockEntity extends RandomizableContainerBlockEntity im
         if (!level.isClientSide && state.getBlock() instanceof CraftingBowlBlock) {
             int stirred = state.getValue(CraftingBowlBlock.STIRRED);
             if (stirring > 0) {
-                Optional<CraftingBowlRecipe> recipe = be.findRecipe(level);
-                if (recipe.isPresent() && stirred < CraftingBowlBlock.STIRS_NEEDED) {
-                    stirred++;
-                    if (stirred == CraftingBowlBlock.STIRS_NEEDED) {
-                        NonNullList<Ingredient> ings = recipe.get().getIngredients();
-                        boolean[] used = new boolean[4];
-                        for (Ingredient ing : ings) {
-                            if (ing.isEmpty()) continue;
-                            for (int i = 0; i < 4; i++) {
-                                if (!used[i] && ing.test(be.getItem(i))) {
-                                    ItemStack stack = be.getItem(i);
-                                    ItemStack remainder = getRemainderItem(stack);
-                                    stack.shrink(1);
-                                    if (stack.isEmpty()) be.setItem(i, ItemStack.EMPTY);
-                                    if (!remainder.isEmpty()) {
-                                        double ox = level.random.nextDouble() * 0.7D + 0.15D;
-                                        double oy = level.random.nextDouble() * 0.7D + 0.15D;
-                                        double oz = level.random.nextDouble() * 0.7D + 0.15D;
-                                        level.addFreshEntity(new ItemEntity(level, pos.getX() + ox, pos.getY() + oy, pos.getZ() + oz, remainder));
-                                    }
-                                    used[i] = true;
-                                    break;
-                                }
-                            }
+                if (stirred < CraftingBowlBlock.STIRS_NEEDED) stirred += 1;
+                if (stirred == CraftingBowlBlock.STIRS_NEEDED) {
+                    Optional<CraftingBowlRecipe> recipe = be.findRecipe(level);
+                    if (recipe.isPresent()) {
+                        stirred += 1;
+                        for (int i = 0; i < 4; i++) {
+                            ItemStack stack = be.getItem(i);
+                            ItemStack remainder = getRemainderItem(stack);
+                            be.setItem(i, remainder);
                         }
                         ItemStack resultItem = recipe.get().getResultItem(level.registryAccess()).copy();
                         resultItem.setCount(recipe.get().getOutputCount());


### PR DESCRIPTION
I saw that it was checking the ingredients against recipes for presumably every tick when stirring, so I've changed the code so that it only matches once when `stirred` is exactly `STIRS_NEEDED` and the bowl has items in it. `stirred` will go above `STIRS_NEEDED` by 1 value if a recipe match is found, so now only values _greater_ than `STIRS_NEEDED` will change the bowl sprite to full.

Some more small changes:

- Any interaction on a finished bowl will always pop out its items. This is so that you dont accidentally add an item into a finished bowl.
- Adding items to the bowl resets its `STIRRED` property. This completes the recipe fix above.
- Remainder items stay in the bowl and is popped out with the result item.
- You can stirr a full bowl even with an item on the hand, for personal convenience :]