### PR TITLE
Add plural common tags for flour and dough

### DIFF
--- a/common/src/main/resources/data/c/tags/item/doughs.json
+++ b/common/src/main/resources/data/c/tags/item/doughs.json
@@ -1,6 +1,6 @@
 {
   "replace": false,
   "values": [
-    "#c:doughs"
+    "farm_and_charm:dough"
   ]
 }

--- a/common/src/main/resources/data/c/tags/item/flour.json
+++ b/common/src/main/resources/data/c/tags/item/flour.json
@@ -1,6 +1,6 @@
 {
   "replace": false,
   "values": [
-    "farm_and_charm:flour"
+    "#c:flours"
   ]
 }

--- a/common/src/main/resources/data/c/tags/item/flours.json
+++ b/common/src/main/resources/data/c/tags/item/flours.json
@@ -1,6 +1,6 @@
 {
   "replace": false,
   "values": [
-    "#c:doughs"
+    "farm_and_charm:flour"
   ]
 }


### PR DESCRIPTION
## Summary

This PR adds plural `c` common tags for Farm & Charm flour and dough while keeping the existing singular tags as legacy aliases.

Added:
- `c:flours`
- `c:doughs`

Updated:
- `c:flour` now references `#c:flours`
- `c:dough` now references `#c:doughs`


## Motivation

The existing singular tags (`c:flour` and `c:dough`) are kept for backward compatibility, but plural tag names are more consistent with the common/conventional tag naming style used by other mods and modding ecosystems.

The Fabric Wiki describes conventional tags as standardized tags in the `c` namespace, intended to reduce inconsistency between mods and allow similar content from different mods to be used interchangeably where appropriate. It also notes that conventional tag names generally use the plural form:

https://wiki.fabricmc.net/tutorial:tags#conventional_tags

This change keeps existing compatibility intact while making Farm & Charm's flour and dough available through plural common tags as well.

## Notes

This PR does not:
- remove the existing singular tags
- change any item IDs
- change any recipes
- add loader-specific behavior

## Testing

- Built the NeoForge jar successfully.
- Tested the generated jar in-game.