### PR TITLE
Fix stove recipe matching with extra ingredients

### DIFF
--- a/common/src/main/java/net/satisfy/farm_and_charm/core/block/entity/StoveBlockEntity.java
+++ b/common/src/main/java/net/satisfy/farm_and_charm/core/block/entity/StoveBlockEntity.java
@@ -310,7 +310,19 @@ public class StoveBlockEntity extends BlockEntity implements BlockEntityTicker<S
         }
 
         List<Integer> plannedSlots = getPlannedIngredientSlots(recipe, inventoryCopy);
-        return plannedSlots != null;
+        if (plannedSlots == null) {
+            return false;
+        }
+
+        // Ensure there are no extra ingredients present.
+        int occupiedIngredientSlots = 0;
+        for (int slot : INGREDIENT_SLOTS) {
+            if (!inventory.get(slot).isEmpty()) {
+                occupiedIngredientSlots++;
+            }
+        }
+
+        return occupiedIngredientSlots == recipe.getIngredients().size();
     }
 
     protected void craft(StoveRecipe recipe, RegistryAccess access) {


### PR DESCRIPTION
Hi! While playing on a survival server, we ran into a small edge case with the stove recipes.

If a 2-ingredient recipe exists alongside a 3-ingredient recipe that shares those two ingredients, the stove will match the 2-ingredient recipe first, even when a third ingredient is present.

For example:

```
Dough + Water = Farmer's Bread (Expected)
Dough + Yeast + Water = Farmer's Bread (Unexpected, expected Crusty Bread)
```

After tracing through the stove matching logic, it looks like `matchesInventory()` only checks whether all recipe ingredients can be assigned to inventory slots. Since it doesn't verify that there are no additional occupied ingredient slots, recipes are effectively treated as subset matches instead of exact matches.

This change requires that the number of occupied ingredient slots matches the recipe ingredient count before considering the recipe a valid match.

I verified the following after the change:

```
Dough + Water = Farmer's Bread
Dough + Yeast + Water = Crusty Bread
Dough + Sugar + Water = Baker's Bread
Dough + Diamond + Water = No recipe (This would have also produced Farmer's Bread!)
```

Thank you all for the great work that goes into this mod!