### PR TITLE
[Fix] Don't Render Background Twice

### DIFF
--- a/common/src/main/java/net/satisfy/farm_and_charm/client/gui/CookingPotGui.java
+++ b/common/src/main/java/net/satisfy/farm_and_charm/client/gui/CookingPotGui.java
@@ -47,7 +47,7 @@ public class CookingPotGui extends AbstractContainerScreen<CookingPotGuiHandler>
 
     @Override
     public void render(GuiGraphics guiGraphics, int mouseX, int mouseY, float delta) {
-        this.renderBackground(guiGraphics, mouseX, mouseY, delta);
+        //this.renderBackground(guiGraphics, mouseX, mouseY, delta);
         super.render(guiGraphics, mouseX, mouseY, delta);
         this.renderTooltip(guiGraphics, mouseX, mouseY);
     }

--- a/common/src/main/java/net/satisfy/farm_and_charm/client/gui/PetBowlEditGui.java
+++ b/common/src/main/java/net/satisfy/farm_and_charm/client/gui/PetBowlEditGui.java
@@ -44,7 +44,7 @@ public class PetBowlEditGui extends Screen {
 
     @Override
     public void render(GuiGraphics graphics, int mouseX, int mouseY, float partialTick) {
-        this.renderBackground(graphics, mouseX, mouseY, partialTick);
+        //this.renderBackground(graphics, mouseX, mouseY, partialTick);
         super.render(graphics, mouseX, mouseY, partialTick);
         graphics.drawCenteredString(this.font, this.title, this.width / 2, 20, 16777215);
     }

--- a/common/src/main/java/net/satisfy/farm_and_charm/client/gui/RoasterGui.java
+++ b/common/src/main/java/net/satisfy/farm_and_charm/client/gui/RoasterGui.java
@@ -47,7 +47,7 @@ public class RoasterGui extends AbstractContainerScreen<RoasterGuiHandler> {
 
     @Override
     public void render(GuiGraphics guiGraphics, int mouseX, int mouseY, float delta) {
-        this.renderBackground(guiGraphics, mouseX, mouseY, delta);
+        //this.renderBackground(guiGraphics, mouseX, mouseY, delta);
         super.render(guiGraphics, mouseX, mouseY, delta);
         this.renderTooltip(guiGraphics, mouseX, mouseY);
     }

--- a/common/src/main/java/net/satisfy/farm_and_charm/client/gui/StoveGui.java
+++ b/common/src/main/java/net/satisfy/farm_and_charm/client/gui/StoveGui.java
@@ -30,7 +30,7 @@ public class StoveGui extends AbstractContainerScreen<StoveGuiHandler> {
 
     @Override
     public void render(GuiGraphics guiGraphics, int mouseX, int mouseY, float delta) {
-        this.renderBackground(guiGraphics, mouseX, mouseY, delta);
+        //this.renderBackground(guiGraphics, mouseX, mouseY, delta);
         super.render(guiGraphics, mouseX, mouseY, delta);
         this.renderTooltip(guiGraphics, mouseX, mouseY);
     }


### PR DESCRIPTION
All of the GUIs inside `net.satisfy.farm_and_charm.client.gui` call `super.renderBakground` in their render function, right before calling `super.render`, this in turn renders the background twice, because `super.render` already calls `super.renderBakground` before rendering anything, this causes "broken visuals" and "performance issues", with mods like Blur+ which adds a blur effect to the background of containers. it also results in the background of these GUIs be very dark, this PR just comments these lines.